### PR TITLE
fix: 修复正则转义警告和 Web 模式持有标志不显示问题

### DIFF
--- a/fund.py
+++ b/fund.py
@@ -299,10 +299,10 @@ class MaYiFund:
                 }
                 url = f"https://www.fund123.cn/matiaria?fundCode={fund}"
                 response = self.session.get(url, headers=headers, timeout=10, verify=False)
-                dayOfGrowth = re.findall('\"dayOfGrowth\"\:\"(.*?)\"', response.text)[0]
+                dayOfGrowth = re.findall(r'"dayOfGrowth":"(.*?)"', response.text)[0]
                 dayOfGrowth = str(round(float(dayOfGrowth), 2)) + "%"
 
-                netValueDate = re.findall('\"netValueDate\"\:\"(.*?)\"', response.text)[0]
+                netValueDate = re.findall(r'"netValueDate":"(.*?)"', response.text)[0]
                 if is_return:
                     dayOfGrowth = f"{dayOfGrowth}({netValueDate})"
 
@@ -407,15 +407,14 @@ class MaYiFund:
                             dayOfGrowth = "\033[1;32m" + dayOfGrowth
                         else:
                             dayOfGrowth = "\033[1;31m" + dayOfGrowth
-                    if not is_return:
-                        # 处理持有标记
-                        if self.CACHE_MAP[fund].get("is_hold", False):
-                            fund_name = "⭐ " + fund_name
-                        # 处理板块标记（独立于持有状态）
-                        sectors = self.CACHE_MAP[fund].get("sectors", [])
-                        if sectors:
-                            sector_str = ",".join(sectors)
-                            fund_name = f"({sector_str}) {fund_name}"
+                    # 处理持有标记和板块标记（Web 和 CLI 模式都显示）
+                    if self.CACHE_MAP[fund].get("is_hold", False):
+                        fund_name = "⭐ " + fund_name
+                    # 处理板块标记（独立于持有状态）
+                    sectors = self.CACHE_MAP[fund].get("sectors", [])
+                    if sectors:
+                        sector_str = ",".join(sectors)
+                        fund_name = f"({sector_str}) {fund_name}"
                     # 合并连涨天数和连涨幅
                     consecutive_info = f"{consecutive_count}天 {consecutive_growth}"
                     # 合并近30天涨跌和总涨幅


### PR DESCRIPTION
## 修复内容

1. **fund.py**: 使用原始字符串 `r"..."` 修复 `SyntaxWarning: invalid escape sequence`
2. **fund.py**: 修复 `search_one_code` 函数，移除 `is_return` 条件限制，使 Web 模式也能正确显示持有基金标志 ⭐

## 问题描述

- Python 3.12+ 对正则表达式中的转义序列发出警告
- Web 模式下持有基金的 ⭐ 标志不显示，只有 CLI 模式下才会显示

## 测试

已在本地测试通过，Web 页面现在正确显示所有持有标记。

## 变更文件

- `fund.py`: +10 / -11 行